### PR TITLE
SDK-181: Persist User Data across app restarts

### DIFF
--- a/Sources/DashX/Constants.swift
+++ b/Sources/DashX/Constants.swift
@@ -3,7 +3,7 @@ import Foundation
 struct Constants {
     static let PACKAGE_NAME = "com.dashx.sdk"
     static let USER_PREFERENCES_KEY_ACCOUNT_UID = "\(PACKAGE_NAME).account_uid"
-    static let USER_PREFERENCES_KEY_ANONYMOUS_UID = "\(PACKAGE_NAME).anonymous_uid"
+    static let USER_PREFERENCES_KEY_ACCOUNT_ANONYMOUS_UID = "\(PACKAGE_NAME).account_anonymous_uid"
     static let USER_PREFERENCES_KEY_IDENTITY_TOKEN = "\(PACKAGE_NAME).identity_token"
     static let USER_PREFERENCES_KEY_DEVICE_TOKEN = "\(PACKAGE_NAME).device_token"
     static let USER_PREFERENCES_KEY_BUILD = "\(PACKAGE_NAME).build"

--- a/Sources/DashX/Constants.swift
+++ b/Sources/DashX/Constants.swift
@@ -5,6 +5,8 @@ struct Constants {
     static let USER_PREFERENCES_KEY_ANONYMOUS_UID = "\(PACKAGE_NAME).anonymous_uid"
     static let USER_PREFERENCES_KEY_DEVICE_TOKEN = "\(PACKAGE_NAME).device_token"
     static let USER_PREFERENCES_KEY_BUILD = "\(PACKAGE_NAME).build"
+    static let USER_PREFERENCES_ACCOUNT_UID = "\(PACKAGE_NAME).account_uid"
+    static let USER_PREFERENCES_IDENTITY_TOKEN = "\(PACKAGE_NAME).identity_token"
     static let INTERNAL_EVENT_APP_INSTALLED = "Application Installed"
     static let INTERNAL_EVENT_APP_UPDATED = "Application Updated"
     static let INTERNAL_EVENT_APP_OPENED = "Application Opened"

--- a/Sources/DashX/Constants.swift
+++ b/Sources/DashX/Constants.swift
@@ -2,11 +2,11 @@ import Foundation
 
 struct Constants {
     static let PACKAGE_NAME = "com.dashx.sdk"
+    static let USER_PREFERENCES_KEY_ACCOUNT_UID = "\(PACKAGE_NAME).account_uid"
     static let USER_PREFERENCES_KEY_ANONYMOUS_UID = "\(PACKAGE_NAME).anonymous_uid"
+    static let USER_PREFERENCES_KEY_IDENTITY_TOKEN = "\(PACKAGE_NAME).identity_token"
     static let USER_PREFERENCES_KEY_DEVICE_TOKEN = "\(PACKAGE_NAME).device_token"
     static let USER_PREFERENCES_KEY_BUILD = "\(PACKAGE_NAME).build"
-    static let USER_PREFERENCES_ACCOUNT_UID = "\(PACKAGE_NAME).account_uid"
-    static let USER_PREFERENCES_IDENTITY_TOKEN = "\(PACKAGE_NAME).identity_token"
     static let INTERNAL_EVENT_APP_INSTALLED = "Application Installed"
     static let INTERNAL_EVENT_APP_UPDATED = "Application Updated"
     static let INTERNAL_EVENT_APP_OPENED = "Application Opened"

--- a/Sources/DashX/DashXClient.swift
+++ b/Sources/DashX/DashXClient.swift
@@ -82,8 +82,8 @@ public class DashXClient {
         
         let preferences = UserDefaults.standard
         
-        preferences.set(self.accountUid, forKey: Constants.USER_PREFERENCES_ACCOUNT_UID)
-        preferences.set(token, forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
+        preferences.set(self.accountUid, forKey: Constants.USER_PREFERENCES_KEY_ACCOUNT_UID)
+        preferences.set(token, forKey: Constants.USER_PREFERENCES_KEY_IDENTITY_TOKEN)
     }
 
     private func generateAnonymousUid(withRegenerate: Bool = false) {
@@ -134,15 +134,15 @@ public class DashXClient {
     
     func loadIdentity() {
         let preferences = UserDefaults.standard
-        self.accountUid = preferences.string(forKey: Constants.USER_PREFERENCES_ACCOUNT_UID)
-        ConfigInterceptor.shared.identityToken = preferences.string(forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
+        self.accountUid = preferences.string(forKey: Constants.USER_PREFERENCES_KEY_ACCOUNT_UID)
+        ConfigInterceptor.shared.identityToken = preferences.string(forKey: Constants.USER_PREFERENCES_KEY_IDENTITY_TOKEN)
     }
 
     func reset() {
         let preferences = UserDefaults.standard
         
-        preferences.removeObject(forKey: Constants.USER_PREFERENCES_ACCOUNT_UID)
-        preferences.removeObject(forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
+        preferences.removeObject(forKey: Constants.USER_PREFERENCES_KEY_ACCOUNT_UID)
+        preferences.removeObject(forKey: Constants.USER_PREFERENCES_KEY_IDENTITY_TOKEN)
         
         self.accountUid = nil
         ConfigInterceptor.shared.identityToken = nil

--- a/Sources/DashX/DashXClient.swift
+++ b/Sources/DashX/DashXClient.swift
@@ -23,6 +23,7 @@ public class DashXClient {
 
     private init() {
         generateAnonymousUid()
+        loadIdentity()
     }
     
     // Hiding the initialiser from user till multiple dash clients support is in place
@@ -78,6 +79,11 @@ public class DashXClient {
     public func setIdentity(uid: String? = nil, token: String? = nil) {
         self.accountUid = uid
         ConfigInterceptor.shared.identityToken = token
+        
+        let preferences = UserDefaults.standard
+        
+        preferences.set(self.accountUid, forKey: Constants.USER_PREFERENCES_ACCOUNT_UID)
+        preferences.set(token, forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
     }
 
     private func generateAnonymousUid(withRegenerate: Bool = false) {
@@ -125,9 +131,23 @@ public class DashXClient {
           }
         }
     }
+    
+    func loadIdentity() {
+        let preferences = UserDefaults.standard
+        setIdentity(
+            uid: preferences.string(forKey: Constants.USER_PREFERENCES_ACCOUNT_UID),
+            token: preferences.string(forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
+        )
+    }
 
     func reset() {
+        let preferences = UserDefaults.standard
+        
+        preferences.removeObject(forKey: Constants.USER_PREFERENCES_ACCOUNT_UID)
+        preferences.removeObject(forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
+        
         self.accountUid = nil
+        ConfigInterceptor.shared.identityToken = nil
         self.generateAnonymousUid(withRegenerate: true)
     }
     // MARK: -- track

--- a/Sources/DashX/DashXClient.swift
+++ b/Sources/DashX/DashXClient.swift
@@ -134,10 +134,8 @@ public class DashXClient {
     
     func loadIdentity() {
         let preferences = UserDefaults.standard
-        setIdentity(
-            uid: preferences.string(forKey: Constants.USER_PREFERENCES_ACCOUNT_UID),
-            token: preferences.string(forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
-        )
+        self.accountUid = preferences.string(forKey: Constants.USER_PREFERENCES_ACCOUNT_UID)
+        ConfigInterceptor.shared.identityToken = preferences.string(forKey: Constants.USER_PREFERENCES_IDENTITY_TOKEN)
     }
 
     func reset() {

--- a/Sources/DashX/DashXClient.swift
+++ b/Sources/DashX/DashXClient.swift
@@ -90,12 +90,12 @@ public class DashXClient {
         let anonymousUidKey = Constants.USER_PREFERENCES_KEY_ACCOUNT_ANONYMOUS_UID
         let storedAnonymousUid = preferences.string(forKey: anonymousUidKey)
         
-        if withRegenerate || storedAnonymousUid == nil {
+        if !withRegenerate && storedAnonymousUid != nil {
+            return storedAnonymousUid
+        } else {
             let uniqueIdentifier = UUID().uuidString
             preferences.set(self.accountAnonymousUid, forKey: anonymousUidKey)
             return uniqueIdentifier
-        } else {
-            return storedAnonymousUid
         }
     }
     // MARK: -- identify
@@ -149,7 +149,7 @@ public class DashXClient {
         preferences.removeObject(forKey: Constants.USER_PREFERENCES_KEY_IDENTITY_TOKEN)
         
         self.accountUid = nil
-        self.accountAnonymousUid = nil
+        self.accountAnonymousUid = self.generateAnonymousUid(withRegenerate: true)
         ConfigInterceptor.shared.identityToken = nil
     }
     // MARK: -- track

--- a/Sources/DashX/DashXClient.swift
+++ b/Sources/DashX/DashXClient.swift
@@ -22,7 +22,6 @@ public class DashXClient {
     private var mustSubscribe: Bool = false;
 
     private init() {
-        generateAnonymousUid()
         loadIdentity()
     }
     
@@ -86,15 +85,17 @@ public class DashXClient {
         preferences.set(token, forKey: Constants.USER_PREFERENCES_KEY_IDENTITY_TOKEN)
     }
 
-    private func generateAnonymousUid(withRegenerate: Bool = false) {
+    private func generateAnonymousUid(withRegenerate: Bool = false) -> String? {
         let preferences = UserDefaults.standard
-        let anonymousUidKey = Constants.USER_PREFERENCES_KEY_ANONYMOUS_UID
-
-        if !withRegenerate && preferences.object(forKey: anonymousUidKey) != nil {
-            self.accountAnonymousUid = preferences.string(forKey: anonymousUidKey) ?? nil
-        } else {
-            self.accountAnonymousUid = UUID().uuidString
+        let anonymousUidKey = Constants.USER_PREFERENCES_KEY_ACCOUNT_ANONYMOUS_UID
+        let storedAnonymousUid = preferences.string(forKey: anonymousUidKey)
+        
+        if withRegenerate || storedAnonymousUid == nil {
+            let uniqueIdentifier = UUID().uuidString
             preferences.set(self.accountAnonymousUid, forKey: anonymousUidKey)
+            return uniqueIdentifier
+        } else {
+            return storedAnonymousUid
         }
     }
     // MARK: -- identify
@@ -134,7 +135,9 @@ public class DashXClient {
     
     func loadIdentity() {
         let preferences = UserDefaults.standard
+        
         self.accountUid = preferences.string(forKey: Constants.USER_PREFERENCES_KEY_ACCOUNT_UID)
+        self.accountAnonymousUid = generateAnonymousUid()
         ConfigInterceptor.shared.identityToken = preferences.string(forKey: Constants.USER_PREFERENCES_KEY_IDENTITY_TOKEN)
     }
 
@@ -142,11 +145,12 @@ public class DashXClient {
         let preferences = UserDefaults.standard
         
         preferences.removeObject(forKey: Constants.USER_PREFERENCES_KEY_ACCOUNT_UID)
+        preferences.removeObject(forKey: Constants.USER_PREFERENCES_KEY_ACCOUNT_ANONYMOUS_UID)
         preferences.removeObject(forKey: Constants.USER_PREFERENCES_KEY_IDENTITY_TOKEN)
         
         self.accountUid = nil
+        self.accountAnonymousUid = nil
         ConfigInterceptor.shared.identityToken = nil
-        self.generateAnonymousUid(withRegenerate: true)
     }
     // MARK: -- track
 

--- a/Sources/DashX/DashXClient.swift
+++ b/Sources/DashX/DashXClient.swift
@@ -94,7 +94,7 @@ public class DashXClient {
             return storedAnonymousUid
         } else {
             let uniqueIdentifier = UUID().uuidString
-            preferences.set(self.accountAnonymousUid, forKey: anonymousUidKey)
+            preferences.set(uniqueIdentifier, forKey: anonymousUidKey)
             return uniqueIdentifier
         }
     }


### PR DESCRIPTION
- `loadIdentity()` being called while initializing the DashXClient to set values from the UserDefaults

- `reset()` updated to remove values for the keys in UserDefaults