### PR TITLE
Fix: Removed Alamofire dependencies from all dependency managers

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
-github "Alamofire/Alamofire" == 5.2.2
 github "apollographql/apollo-ios" == 0.39.0
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,1 @@
-github "Alamofire/Alamofire" "5.2.2"
 github "apollographql/apollo-ios" "0.39.0"

--- a/DashX.podspec
+++ b/DashX.podspec
@@ -135,7 +135,6 @@ Pod::Spec.new do |spec|
   # spec.requires_arc = true
 
   # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  spec.dependency 'Alamofire', '~> 4.7'
   spec.dependency 'Apollo', '~> 0.51.2'
 
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "Alamofire",
-        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
-        "state": {
-          "branch": null,
-          "revision": "f96b619bcb2383b43d898402283924b80e2c4bae",
-          "version": "5.4.3"
-        }
-      },
-      {
         "package": "Apollo",
         "repositoryURL": "https://github.com/apollographql/apollo-ios.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,7 @@ let package = Package(
             targets: ["DashX"]),
     ],
     dependencies: [
-        .package(name: "Alamofire", url: "https://github.com/Alamofire/Alamofire.git", from: "5.2.2"),
-        .package(name: "Apollo", url: "https://github.com/apollographql/apollo-ios.git", from: "0.52.0"),
+        .package(name: "Apollo", url: "https://github.com/apollographql/apollo-ios.git", from: "0.52.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -22,7 +21,6 @@ let package = Package(
         .target(
             name: "DashX",
             dependencies: [
-                .product(name: "Alamofire", package: "Alamofire"),
                 .product(name: "Apollo", package: "Apollo")
             ]
         ),

--- a/Sources/DashX/Utils.swift
+++ b/Sources/DashX/Utils.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Foundation
 import MobileCoreServices
 
 extension URL {


### PR DESCRIPTION
* Removed Alamofire, since it isn't in use

* Ran `lint`, now there are no warnings.
<img width="983" alt="Screenshot 2022-08-18 at 4 06 18 PM" src="https://user-images.githubusercontent.com/47970992/185375852-0b673a60-e30f-4a3e-a689-e79655b8e832.png">
