### PR TITLE
Setup Github Actions to publish new release to Cocoapods 

### DIFF
--- a/.github/workflows/publish-to-cocoapods.yml
+++ b/.github/workflows/publish-to-cocoapods.yml
@@ -1,0 +1,26 @@
+name: Publish to Cocoapods 
+
+on:
+# Triggers the workflow when a "tag" is made and pushed
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Install Cocoapods
+      run: gem install cocoapods
+      
+    - name: Deploy to Cocoapods
+      run: |
+        set -eo pipefail
+        pod lib lint --allow-warnings
+        pod trunk push --allow-warnings
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
 * Created `publish-to-cocoapods` workflow to publish when a tag is made and pushed
